### PR TITLE
Added support for the CLI's "--category" and "--entity-type" parameters.

### DIFF
--- a/src/WakaTime.Shared.ExtensionUtils/EnumExtensions.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/EnumExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace WakaTime.Shared.ExtensionUtils
 {
@@ -12,7 +8,8 @@ namespace WakaTime.Shared.ExtensionUtils
     {
         public static string GetDescription(this Enum e)
         {
-            DescriptionAttribute attr = (DescriptionAttribute)e.GetType().GetField(e.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault();
+            var attr = (DescriptionAttribute) e.GetType().GetField(e.ToString())
+                .GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault();
             return attr?.Description ?? e.ToString();
         }
     }

--- a/src/WakaTime.Shared.ExtensionUtils/EnumExtensions.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/EnumExtensions.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace WakaTime.Shared.ExtensionUtils
 {
-    public static class Extensions
+    public static class EnumExtensions
     {
         public static string GetDescription(this Enum e)
         {

--- a/src/WakaTime.Shared.ExtensionUtils/Enums.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Enums.cs
@@ -11,31 +11,22 @@ namespace WakaTime.Shared.ExtensionUtils
     {
         [Description("coding")]
         Coding,
-
         [Description("building")]
         Building,
-
         [Description("indexing")]
         Indexing,
-
         [Description("debugging")]
         Debugging,
-
-        [Description("running_tests")]
+        [Description("running tests")]
         RunningTests,
-
-        [Description("writing_tests")]
+        [Description("writing tests")]
         WritingTests,
-
-        [Description("manual_testing")]
+        [Description("manual testing")]
         ManualTesting,
-
-        [Description("code_reviewing")]
+        [Description("code reviewing")]
         CodeReviewing,
-
         [Description("browsing")]
         Browsing,
-
         [Description("designing")]
         Designing
     }
@@ -44,10 +35,8 @@ namespace WakaTime.Shared.ExtensionUtils
     {
         [Description("file")]
         File,
-
         [Description("domain")]
         Domain,
-
         [Description("app")]
         App
     }

--- a/src/WakaTime.Shared.ExtensionUtils/Enums.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Enums.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
+// ReSharper disable UnusedMember.Global
 
 namespace WakaTime.Shared.ExtensionUtils
 {

--- a/src/WakaTime.Shared.ExtensionUtils/Enums.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Enums.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WakaTime.Shared.ExtensionUtils
+{
+    public enum HeartbeatCategory
+    {
+        [Description("coding")]
+        Coding,
+
+        [Description("building")]
+        Building,
+
+        [Description("indexing")]
+        Indexing,
+
+        [Description("debugging")]
+        Debugging,
+
+        [Description("running_tests")]
+        RunningTests,
+
+        [Description("writing_tests")]
+        WritingTests,
+
+        [Description("manual_testing")]
+        ManualTesting,
+
+        [Description("code_reviewing")]
+        CodeReviewing,
+
+        [Description("browsing")]
+        Browsing,
+
+        [Description("designing")]
+        Designing
+    }
+
+    public enum EntityType
+    {
+        [Description("file")]
+        File,
+
+        [Description("domain")]
+        Domain,
+
+        [Description("app")]
+        App
+    }
+}

--- a/src/WakaTime.Shared.ExtensionUtils/Extensions.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Extensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WakaTime.Shared.ExtensionUtils
+{
+    public static class Extensions
+    {
+        public static string GetDescription(this Enum e)
+        {
+            DescriptionAttribute attr = (DescriptionAttribute)e.GetType().GetField(e.ToString()).GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault();
+            return attr?.Description ?? e.ToString();
+        }
+    }
+}

--- a/src/WakaTime.Shared.ExtensionUtils/Heartbeat.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Heartbeat.cs
@@ -9,40 +9,4 @@
         public HeartbeatCategory Category { get; set; }
         public EntityType EntityType { get; set; }
     }
-
-    /* Matheus Rocha (MattLebrao) on Aug 31 2020 @ 19h28:
-     * 
-     * According to cli file "https://github.com/wakatime/wakatime-cli/blob/435b6c667bc2e426f284cd1de38fb168ec82ebcf/cmd/root.go#L45":
-     * 
-     * Possible values for the category parameter are: "coding", "building", "indexing", "debugging", "running tests", "writing tests",
-     *                                                 "manual testing", "code reviewing", "browsing" and "designing".
-     * Considering it has a set of valid values it makes sense to make an enum out of it, and use it with "ToString().Replace('_', ' ')".
-     */
-    public enum HeartbeatCategory
-    {
-        coding,
-        building,
-        indexing,
-        debugging,
-        running_tests,
-        writing_tests,
-        manual_testing,
-        code_reviewing,
-        browsing,
-        designing
-    }
-
-    /* Matheus Rocha (MattLebrao) on Aug 31 2020 @ 21h32:
-     * 
-     * According to cli file "https://github.com/wakatime/wakatime-cli/blob/435b6c667bc2e426f284cd1de38fb168ec82ebcf/cmd/root.go#L67":
-     * 
-     * Possible values for the entity type paramater are: "file", "domain", "app".
-     * Considering it has a set of valid values it makes sense to make an enum out of it, and use it with "ToString()".
-     */
-    public enum EntityType
-    {
-        file,
-        domain,
-        app
-    }
 }

--- a/src/WakaTime.Shared.ExtensionUtils/Heartbeat.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Heartbeat.cs
@@ -6,5 +6,43 @@
         public string Timestamp { get; set; }
         public string Project { get; set; }
         public bool IsWrite { get; set; }
+        public HeartbeatCategory Category { get; set; }
+        public EntityType EntityType { get; set; }
+    }
+
+    /* Matheus Rocha (MattLebrao) on Aug 31 2020 @ 19h28:
+     * 
+     * According to cli file "https://github.com/wakatime/wakatime-cli/blob/435b6c667bc2e426f284cd1de38fb168ec82ebcf/cmd/root.go#L45":
+     * 
+     * Possible values for the category parameter are: "coding", "building", "indexing", "debugging", "running tests", "writing tests",
+     *                                                 "manual testing", "code reviewing", "browsing" and "designing".
+     * Considering it has a set of valid values it makes sense to make an enum out of it, and use it with "ToString().Replace('_', ' ')".
+     */
+    public enum HeartbeatCategory
+    {
+        coding,
+        building,
+        indexing,
+        debugging,
+        running_tests,
+        writing_tests,
+        manual_testing,
+        code_reviewing,
+        browsing,
+        designing
+    }
+
+    /* Matheus Rocha (MattLebrao) on Aug 31 2020 @ 21h32:
+     * 
+     * According to cli file "https://github.com/wakatime/wakatime-cli/blob/435b6c667bc2e426f284cd1de38fb168ec82ebcf/cmd/root.go#L67":
+     * 
+     * Possible values for the entity type paramater are: "file", "domain", "app".
+     * Considering it has a set of valid values it makes sense to make an enum out of it, and use it with "ToString()".
+     */
+    public enum EntityType
+    {
+        file,
+        domain,
+        app
     }
 }

--- a/src/WakaTime.Shared.ExtensionUtils/Heartbeat.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Heartbeat.cs
@@ -6,7 +6,7 @@
         public string Timestamp { get; set; }
         public string Project { get; set; }
         public bool IsWrite { get; set; }
-        public HeartbeatCategory Category { get; set; }
-        public EntityType EntityType { get; set; }
+        public HeartbeatCategory? Category { get; set; }
+        public EntityType? EntityType { get; set; }
     }
 }

--- a/src/WakaTime.Shared.ExtensionUtils/PythonCliParameters.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/PythonCliParameters.cs
@@ -4,20 +4,13 @@ using System.Linq;
 namespace WakaTime.Shared.ExtensionUtils
 {
     public class PythonCliParameters
-    {
-        private readonly Dependencies _dependencies;
-
-        public PythonCliParameters()
-        {
-            _dependencies = new Dependencies();
-        }
-
+    {        
         public string Key { get; set; }
         public string File { get; set; }
         public string Time { get; set; }
         public string Plugin { get; set; }
-        public HeartbeatCategory Category { get; set; }
-        public EntityType EntityType { get; set; }
+        public HeartbeatCategory? Category { get; set; }
+        public EntityType? EntityType { get; set; }
         public bool IsWrite { get; set; }
         public string Project { get; set; }
         public bool HasExtraHeartbeats { get; set; }
@@ -33,15 +26,20 @@ namespace WakaTime.Shared.ExtensionUtils
                 "--time",
                 Time,
                 "--plugin",
-                Plugin,
-                "--category",
-                Category.GetDescription(),
-                "--entity-type",
-                EntityType.GetDescription()
+                Plugin                
             };
 
-            if (IsWrite)
-                parameters.Add("--write");
+            if (Category != null)
+            {
+                parameters.Add("--category");
+                parameters.Add(Category.GetDescription());
+            }
+
+            if (EntityType != null)
+            {
+                parameters.Add("--entity-type");
+                parameters.Add(EntityType.GetDescription());
+            }            
 
             // ReSharper disable once InvertIf
             if (!string.IsNullOrEmpty(Project))
@@ -49,6 +47,9 @@ namespace WakaTime.Shared.ExtensionUtils
                 parameters.Add("--project");
                 parameters.Add(Project);
             }
+
+            if (IsWrite)
+                parameters.Add("--write");
 
             if (HasExtraHeartbeats)
                 parameters.Add("--extra-heartbeats");

--- a/src/WakaTime.Shared.ExtensionUtils/PythonCliParameters.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/PythonCliParameters.cs
@@ -35,9 +35,9 @@ namespace WakaTime.Shared.ExtensionUtils
                 "--plugin",
                 Plugin,
                 "--category",
-                Category.ToString().Replace('_', ' '),
+                Category.GetDescription(),
                 "--entity-type",
-                EntityType.ToString()
+                EntityType.GetDescription()
             };
 
             if (IsWrite)

--- a/src/WakaTime.Shared.ExtensionUtils/PythonCliParameters.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/PythonCliParameters.cs
@@ -16,6 +16,8 @@ namespace WakaTime.Shared.ExtensionUtils
         public string File { get; set; }
         public string Time { get; set; }
         public string Plugin { get; set; }
+        public HeartbeatCategory Category { get; set; }
+        public EntityType EntityType { get; set; }
         public bool IsWrite { get; set; }
         public string Project { get; set; }
         public bool HasExtraHeartbeats { get; set; }
@@ -31,7 +33,11 @@ namespace WakaTime.Shared.ExtensionUtils
                 "--time",
                 Time,
                 "--plugin",
-                Plugin
+                Plugin,
+                "--category",
+                Category.ToString().Replace('_', ' '),
+                "--entity-type",
+                EntityType.ToString()
             };
 
             if (IsWrite)

--- a/src/WakaTime.Shared.ExtensionUtils/WakaTime.Shared.ExtensionUtils.csproj
+++ b/src/WakaTime.Shared.ExtensionUtils/WakaTime.Shared.ExtensionUtils.csproj
@@ -135,6 +135,8 @@
     <Compile Include="Configuration.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Dependencies.cs" />
+    <Compile Include="Enums.cs" />
+    <Compile Include="EnumExtensions.cs" />
     <Compile Include="GuidList.cs" />
     <Compile Include="Heartbeat.cs" />
     <Compile Include="ILogger.cs" />

--- a/src/WakaTime.Shared.ExtensionUtils/WakaTime.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/WakaTime.cs
@@ -79,7 +79,7 @@ namespace WakaTime.Shared.ExtensionUtils
         }
 
         public void HandleActivity(string currentFile, bool isWrite, string project,
-                                   HeartbeatCategory activity = HeartbeatCategory.Coding, EntityType entityType = EntityType.File)
+            HeartbeatCategory? category = null, EntityType? entityType = null)
         {
             if (currentFile == null)
                 return;
@@ -92,10 +92,11 @@ namespace WakaTime.Shared.ExtensionUtils
             _lastFile = currentFile;
             _lastHeartbeat = now;
 
-            AppendHeartbeat(currentFile, isWrite, now, project, activity, entityType);
+            AppendHeartbeat(currentFile, isWrite, now, project, category, entityType);
         }
 
-        private void AppendHeartbeat(string fileName, bool isWrite, DateTime time, string project, HeartbeatCategory category, EntityType entityType)
+        private void AppendHeartbeat(string fileName, bool isWrite, DateTime time, string project,
+            HeartbeatCategory? category, EntityType? entityType)
         {
             var h = new Heartbeat
             {

--- a/src/WakaTime.Shared.ExtensionUtils/WakaTime.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/WakaTime.cs
@@ -78,7 +78,9 @@ namespace WakaTime.Shared.ExtensionUtils
             Logger.Info($"Finished initializing WakaTime v{_configuration.PluginVersion}");
         }
 
-        public void HandleActivity(string currentFile, bool isWrite, string project)
+        //Added "activity" and "entityType" as optional parameters to preserve backwards compatbility.
+        public void HandleActivity(string currentFile, bool isWrite, string project,
+                                   HeartbeatCategory activity = HeartbeatCategory.coding, EntityType entityType = EntityType.file)
         {
             if (currentFile == null)
                 return;
@@ -91,17 +93,19 @@ namespace WakaTime.Shared.ExtensionUtils
             _lastFile = currentFile;
             _lastHeartbeat = now;
 
-            AppendHeartbeat(currentFile, isWrite, now, project);
+            AppendHeartbeat(currentFile, isWrite, now, project, activity, entityType);
         }
 
-        private void AppendHeartbeat(string fileName, bool isWrite, DateTime time, string project)
+        private void AppendHeartbeat(string fileName, bool isWrite, DateTime time, string project, HeartbeatCategory category, EntityType entityType)
         {
             var h = new Heartbeat
             {
                 Entity = fileName,
                 Timestamp = ToUnixEpoch(time),
                 IsWrite = isWrite,
-                Project = project
+                Project = project,
+                Category = category,
+                EntityType = entityType
             };
             HeartbeatQueue.Enqueue(h);
         }
@@ -137,6 +141,8 @@ namespace WakaTime.Shared.ExtensionUtils
             _pythonCliParameters.Time = heartbeat.Timestamp;
             _pythonCliParameters.IsWrite = heartbeat.IsWrite;
             _pythonCliParameters.Project = heartbeat.Project;
+            _pythonCliParameters.Category = heartbeat.Category;
+            _pythonCliParameters.EntityType = heartbeat.EntityType;
             _pythonCliParameters.HasExtraHeartbeats = hasExtraHeartbeats;
 
             string extraHeartbeatsJson = null;

--- a/src/WakaTime.Shared.ExtensionUtils/WakaTime.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/WakaTime.cs
@@ -78,9 +78,8 @@ namespace WakaTime.Shared.ExtensionUtils
             Logger.Info($"Finished initializing WakaTime v{_configuration.PluginVersion}");
         }
 
-        //Added "activity" and "entityType" as optional parameters to preserve backwards compatbility.
         public void HandleActivity(string currentFile, bool isWrite, string project,
-                                   HeartbeatCategory activity = HeartbeatCategory.coding, EntityType entityType = EntityType.file)
+                                   HeartbeatCategory activity = HeartbeatCategory.Coding, EntityType entityType = EntityType.File)
         {
             if (currentFile == null)
                 return;
@@ -107,6 +106,7 @@ namespace WakaTime.Shared.ExtensionUtils
                 Category = category,
                 EntityType = entityType
             };
+
             HeartbeatQueue.Enqueue(h);
         }
 


### PR DESCRIPTION
Overall, only small changes were made to the project.

- Heartbeat.cs file:
    - `Heartbeat` class:
        - Added `Category` and `EntityType` properties.
    - `WakaTime.Shared.ExtensionUtils` namespace:
        - Added two enum types (`HearbeatCategory` and `EntityType`) for the valid values of CLI's "category" and "entity-type" parameters. 
        - See valid values in CLI file **wakatime/wakatime-cli/cmd/root.go** lines [45](https://github.com/wakatime/wakatime-cli/blob/435b6c667bc2e426f284cd1de38fb168ec82ebcf/cmd/root.go#L45) and [67](https://github.com/wakatime/wakatime-cli/blob/435b6c667bc2e426f284cd1de38fb168ec82ebcf/cmd/root.go#L67)


- WakaTime.cs file:
    - `WakaTime` class:
        - `HandleActivity` method:
            - Added two optional parameters (`activity` and `entityType`) for the `category` and `entityType` of the `AppendHeartbeat` method (optional to maintain backwards compatbility -- could be replaced with a method overload).
        - `AppendHeartbeat` method:
            - Added two parameters (`category` and `entityType`) for the the `Category` and `EntityType` properties of `Heartbeat` object (no need worry about backwards compatbility since this is a private member).

- PythonCliParameters.cs file:
    - `PythonCliParameters` class:
        - Added `Category` and `EntityType` properties.
        - `ToArray` method:
            - Included newly created properties' values with the proper CLI parameter names in the returning `parameters` collection.

- AssemblyInfo.cs file:
    - Set versions' revision numbers to +1.