### PR TITLE
only throw exception when install failed

### DIFF
--- a/src/WakaTime.Shared.ExtensionUtils/Dependencies.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/Dependencies.cs
@@ -54,8 +54,19 @@ namespace WakaTime.Shared.ExtensionUtils
 
         private async Task CheckAndInstallCli()
         {
-            if (!IsCliInstalled() || !await IsCliLatest())
-                await InstallCli();
+            var installed = IsCliInstalled();
+            if (!installed || !await IsCliLatest())
+            {
+                try
+                {
+                    await InstallCli();
+                }
+                catch (Exception ex)
+                {
+                    if (!installed) throw;
+                    Logger.Error($"Error updating", ex);
+                }
+            }
         }
 
         private async Task InstallCli()


### PR DESCRIPTION
When update failed, we should allow user to use old version client to send heartbeats