### PR TITLE
Use alternate project to keep project consistent across IDEs

### DIFF
--- a/src/WakaTime.Shared.ExtensionUtils/CliParameters.cs
+++ b/src/WakaTime.Shared.ExtensionUtils/CliParameters.cs
@@ -44,7 +44,7 @@ namespace WakaTime.Shared.ExtensionUtils
             // ReSharper disable once InvertIf
             if (!string.IsNullOrEmpty(Project))
             {
-                parameters.Add("--project");
+                parameters.Add("--alternate-project");
                 parameters.Add(Project);
             }
 


### PR DESCRIPTION
We should always use `--alternate-project` not `--project`, so the `Git` project is used first to keep project names consistent across multiple IDEs. For ex: Vim doesn't know about Visual Studio's solution name, but using the Git repo keeps the same project name across both.